### PR TITLE
format spiffs if initial mount fails

### DIFF
--- a/src/OXRS_API.cpp
+++ b/src/OXRS_API.cpp
@@ -15,15 +15,16 @@ OXRS_MQTT * _apiMqtt;
 uint8_t restart = 0;
 
 /* File system helpers */
-void _mountFS()
+boolean _mountFS()
 {
   Serial.print(F("[api ] mounting SPIFFS..."));
   if (!SPIFFS.begin())
   { 
-    Serial.println(F("failed, might need formatting?"));
-    return; 
+    Serial.println(F("failed"));
+    return false; 
   }
   Serial.println(F("done"));
+  return true;
 }
 
 boolean _formatFS()
@@ -196,7 +197,10 @@ OXRS_API::OXRS_API(OXRS_MQTT& mqtt)
 void OXRS_API::begin()
 {
   // Mount the file system
-  _mountFS();
+  if (!_mountFS())
+  {
+    _formatFS();
+  }
 
   // Restore any persisted MQTT settings
   DynamicJsonDocument json(2048);


### PR DESCRIPTION
This was the way it initially worked but we removed it when we thought we would be storing LCD logos in SPIFFS.

Without this, a brand new ESP32 is going to fail on initial boot until the user manually formats the SPIFFS or calls `/factoryReset` [POST] with `{"formatFileSystem":true}` as the payload.

This change makes that initial bootup easier by automatically formatting the SPIFFS if the firmware is unable to mount for whatever reason - usually because it hasn't been formatted yet, but are there other reasons?

Are we happy to be this aggressive for the SPIFFS formatting?