### PR TITLE
move _eraseWifiCreds() into _loop()

### DIFF
--- a/src/OXRS_API.h
+++ b/src/OXRS_API.h
@@ -54,6 +54,7 @@ class OXRS_API
 
     void _initialiseRestApi(void);
     void _checkRestart(void);
+    void _checkDisconnect(void);
 };
 
 #endif


### PR DESCRIPTION
At further testing the wifi FW I ran into issues resetting the wifi credentials from the AdminUI. The ESP wasn't reset and locked up.

After looking closer into it I came to the following conclusion:
Resetting of WiFi credentials includes stopping the WiFi.  Trying to send a HTTP response over WiFi after shutting down WiFi seems to be wrong. So I moved the _eraseWifiCreds() into the loop() by just setting a flag and handling it in a similar fashion as done with reset.
With this change restting of WiFi credentials or factoty reset from AdminUI is nicely getting a HTTP response before resetted.

What do you think?